### PR TITLE
Fix typo in disableAppArmor message

### DIFF
--- a/disableAppArmor.js
+++ b/disableAppArmor.js
@@ -1,7 +1,7 @@
 const { exec } = require('child_process');
 
 function disableAppArmor() {
-  exec("gnome-terminal --maximize --title='Frist launch need root access' --zoom=2 -- sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0", (error, stdout, stderr) => {
+  exec("gnome-terminal --maximize --title='First launch need root access' --zoom=2 -- sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0", (error, stdout, stderr) => {
     if (error) {
       console.error(`Error executing command: ${error.message}`);
       return;


### PR DESCRIPTION
## Summary
- fix typo in the message displayed when disabling AppArmor

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6840bcebe53c8324a55ea172f6d16d64