### PR TITLE
Fix proxy message interpolation

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -30,7 +30,7 @@ class Proxy extends EventEmitter {
             this.lastTotalSent = this.totalSent;
             this.lastTotalReceived = this.totalReceived;
         }, 1000);
-        this.proxy.listen(this.port, () => console.log('Proxy sur ${this.host}:${this.port}'));
+        this.proxy.listen(this.port, () => console.log(`Proxy sur ${this.host}:${this.port}`));
     }
 
     // HTTP “normales”


### PR DESCRIPTION
## Summary
- interpolate `this.host` and `this.port` in the proxy startup log

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "const Proxy=require('./proxy'); new Proxy('example.com', 8080);"`

------
https://chatgpt.com/codex/tasks/task_e_6840bcf20338832484bfdfef7f73e31d