### PR TITLE
Switch tests to Jest

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,6 +78,14 @@ Le contenu du fichier se présente ainsi:
   "spotify-refresh-token":  "VOTRE_SPOTIFY_REFRESH_TOKEN"
 }
 ```
+### Exécution des tests
+
+Des tests unitaires simples sont fournis avec **Jest** pour vérifier certaines fonctions d'utilitaires. Pour les lancer, exécutez :
+
+```bash
+npm test
+```
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "version": "electron -v",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "build:linux": "electron-builder --linux deb"
+    "build:linux": "electron-builder --linux deb",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -86,6 +87,7 @@
     "electron-builder": "^24.13.3",
     "electron-rebuild": "^3.2.9",
     "electron-updater": "^6.6.2",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "jest": "^29.7.0"
   }
 }

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,15 @@
+const Utils = require('../src/classes/Utils');
+
+describe('Utils format functions', () => {
+  const utils = new Utils();
+
+  test('formatNumberDec returns correct decimals', () => {
+    expect(utils.formatNumberDec(5)).toBe('5.0');
+    expect(utils.formatNumberDec(5.25)).toBe('5.25');
+  });
+
+  test('formatNumberLen adds leading zero when needed', () => {
+    expect(utils.formatNumberLen(3)).toBe('03');
+    expect(utils.formatNumberLen(12)).toBe('12');
+  });
+});


### PR DESCRIPTION
## Summary
- update tests to use Jest
- run Jest via npm test
- document tests using Jest in README

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6840beb97ad8832489787f15256aef7c